### PR TITLE
ci: replace Docker-based coverage reporting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,23 +35,11 @@ jobs:
         with:
           files: reports/junit.xml
 
-      - name: Code Coverage Summary Report
-        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
+      - name: Code Coverage Report
+        uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2.12.2
         with:
-          format: markdown
-          output: file
-          hide_complexity: false
-          badge: true
-          filename: reports/coverage/unit/cobertura-coverage.xml
-
-      - name: Publish code coverage report
-        run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
-        with:
-          recreate: true
-          path: code-coverage-results.md
+          json-summary-path: reports/coverage/unit/coverage-summary.json
+          json-final-path: reports/coverage/unit/coverage-final.json
 
       - name: 📦 Build
         run: pnpm build

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ if (!isCi) {
   coverageReporters.push('html');
 } else {
   testReporters.push('junit');
-  coverageReporters.push('cobertura');
+  coverageReporters.push('json-summary', 'json');
 }
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

- replace the Docker-based `irongut/CodeCoverageSummary` step with the Node 24-based `davelosert/vitest-coverage-report-action`
- generate Vitest's `json-summary` and `json` coverage reports in CI
- let the replacement action publish both the job summary and pull request comment
- remove the separate Markdown append and sticky-comment steps

## Why

The existing coverage summary action requires Docker. The replacement consumes Vitest's native JSON reports and runs directly under Node while preserving the coverage summary and PR comment.

## Impact

Runtime, release, test, JUnit publication, permissions, and runner behavior are unchanged. Vitest continues to enforce 100% coverage.

## Validation

- `CI=true corepack pnpm test` — 32 tests pass; 100% statements, branches, functions, and lines
- confirmed `coverage-summary.json` and `coverage-final.json` are generated
- `corepack pnpm lint:ci`
- `corepack pnpm lint:package`
- `corepack pnpm build`
- `git diff --check`

The broader `corepack pnpm lint` command still fails on the default branch's existing TypeScript 7 configuration because inherited `suppressImplicitAnyIndexErrors`, `downlevelIteration`, and `moduleResolution=node10` options are no longer accepted. This PR does not alter that configuration.